### PR TITLE
Remove remains of Linux armv7l support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@
 FROM maven:3.9.9-eclipse-temurin-17-focal AS native-builder
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends git build-essential curl
-# Add kitware repo for newer cmake (improves armv7l support)
+# Add Kitware repo for newer CMake version
 RUN curl -s https://apt.kitware.com/kitware-archive.sh | bash -s
-# Install cmake
+# Install CMake
 RUN apt-get update && apt-get install -y --no-install-recommends cmake
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ git submodule update --init
 
 ### Build with Docker (Recommended)
 
-You can build for all supported Linux platforms (amd64, arm64, armv7l) using Docker:
+You can build for all supported Linux platforms (`amd64`, `arm64`) using Docker:
 
 ```shell
 ./build_linux-all.sh

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -10,8 +10,6 @@ case $AARCH in
         AARCH="amd64" ;;
     aarch64|arm64)
         AARCH="arm64" ;;
-    arm|armhf|armv7l)
-        AARCH="armv7l" ;;
     *)
         echo "Unsupported architecture: ${AARCH}"
         exit 1 ;;


### PR DESCRIPTION
armv7l support was removed when upgrading to Piper 1.4.1 as Piper 1.4.1 uses a onnxruntime version where no Linux armv7l builds exist.